### PR TITLE
The top and left edges of checked objects were not registering as ove…

### DIFF
--- a/flixel/FlxObject.hx
+++ b/flixel/FlxObject.hx
@@ -781,7 +781,7 @@ class FlxObject extends FlxBasic
 	{
 		if (!InScreenSpace)
 		{
-			return (point.x > x) && (point.x < x + width) && (point.y > y) && (point.y < y + height);
+			return (point.x >= x) && (point.x < x + width) && (point.y >= y) && (point.y < y + height);
 		}
 		
 		if (Camera == null)
@@ -792,7 +792,7 @@ class FlxObject extends FlxBasic
 		var yPos:Float = point.y - Camera.scroll.y;
 		getScreenPosition(_point, Camera);
 		point.putWeak();
-		return (xPos > _point.x) && (xPos < _point.x + width) && (yPos > _point.y) && (yPos < _point.y + height);
+		return (xPos >= _point.x) && (xPos < _point.x + width) && (yPos >= _point.y) && (yPos < _point.y + height);
 	}
 	
 	/**


### PR DESCRIPTION
…rlapping, when they should be.  (Consider the example of a single pixel at 0,0: the former could would never register an overlap with the mouse, always looking for your position to be > 0 and < 1.  Even though it's a float, it still gets updated to integer values when you move the mouse.)

May seem trivial, but when you have a button at the edge of a full-screen game, it becomes important.
