### PR TITLE
EditableTextField: fix native compilation with OpenFL <= 3.6.0

### DIFF
--- a/flixel/system/debug/watch/EditableTextField.hx
+++ b/flixel/system/debug/watch/EditableTextField.hx
@@ -73,7 +73,7 @@ class EditableTextField extends TextField implements IFlxDestroyable
 					setSelection(0, 0);
 			case Keyboard.DOWN:
 				if (!modifyNumericValue(-1))
-					setSelection(length, length);
+					setSelection(text.length, text.length);
 		}
 	}
 	


### PR DESCRIPTION
Seems like TextField#length was implemented only recently on legacy.
Closes #1819
